### PR TITLE
Make reflect-metadata a dependency instead of devDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Auto Reggol Changelog
+ 
+## 0.1.4 (May 16, 2022)
+
+- Make `reflect-metadata` a dependency instead of a devDependency.
+ 
+## 0.1.3 (November 24, 2021)
+
+- Add keywords
 
 ## 0.1.2 (March 9, 2021)
+
 - Improve exports so importing from the library looks more natural.
 
 ## 0.1.1 (March 7, 2021)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoreggol",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A collection of handy auto logging decorators.",
   "author": "Ronnie Magatti <ronniemagatti@gmail.com>",
   "main": "build/index.js",
@@ -39,9 +39,10 @@
   "files": [
     "/build/*"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "reflect-metadata": "^0.1.13"
+  },
   "devDependencies": {
-    "reflect-metadata": "^0.1.13",
     "ts-node-dev": "^1.1.1",
     "typescript": "^4.2.2"
   }


### PR DESCRIPTION
This lib imports `reflect-metadata` so it should have been a dependency instead of devDependency all along.