### PR TITLE
Renamed `enablePropertyLoging` to `enablePropertyLogging`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Auto Reggol Changelog
- 
+
+# 0.4.0 (December 21, 2023)
+- Renamed `enablePropertyLoging` to `enablePropertyLogging`.
+
 ## 0.3.0 (September 26, 2022)
 
 - Add a new class decorator `@AutoLogBypassClass` to disable logging for the entire class.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ const logger: LogFunction = (ctr, targetKey, targetValue, level) => {
 Pass the logger function into the `@AutoLog` decorator.
 
 ```typescript
-@AutoLog({ logger, level: "debug", enablePropertyLoging: true })
+@AutoLog({ logger, level: "debug", enablePropertyLogging: true })
 class Example {}
 ```
 
@@ -34,7 +34,7 @@ const logger: LogFunction = (ctr, targetKey, targetValue, level) => {
   console.log(`${level}: ${ctr.name}.${targetKey.toString()}`, targetValue);
 };
 
-@AutoLog({ logger, level: "debug", enablePropertyLoging: true })
+@AutoLog({ logger, level: "debug", enablePropertyLogging: true })
 class Example {
   private a = "foo";
   private b = "bar";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoreggol",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A collection of handy auto logging decorators.",
   "author": "Ronnie Magatti <ronniemagatti@gmail.com>",
   "main": "build/index.js",

--- a/src/base.ts
+++ b/src/base.ts
@@ -10,7 +10,7 @@ export const enum MetadataKey {
 export interface AutoLogOptions {
   logger: LogFunction;
   level?: Level;
-  enablePropertyLoging?: boolean;
+  enablePropertyLogging?: boolean;
   enableLogging?: boolean;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { MetadataKey, AutoLogOptions, ConstructorType, Level } from "./base";
 function AutoLog({
   logger,
   level = "info",
-  enablePropertyLoging = false,
+  enablePropertyLogging = false,
   enableLogging = true,
 }: AutoLogOptions) {
   return function _autolog<T extends ConstructorType>(constructor: T) {
@@ -51,7 +51,7 @@ function AutoLog({
                 };
               } else {
 
-                if (enablePropertyLoging && !bypassLogging) {
+                if (enablePropertyLogging && !bypassLogging) {
                   logger(constructor, propKey, targetValue, LEVEL);
                 }
 

--- a/test/manual-test.ts
+++ b/test/manual-test.ts
@@ -14,7 +14,7 @@ const logger: LogFunction = (ctr, targetKey, targetValue, level) => {
   console.log(`${level}: ${ctr.name}.${targetKey.toString()}`, targetValue);
 };
 
-@AutoLog({ logger, level: "debug", enablePropertyLoging: true })
+@AutoLog({ logger, level: "debug", enablePropertyLogging: true })
 class Example {
   private a = "foo";
   private b = "bar";

--- a/test/vitest/index.test.ts
+++ b/test/vitest/index.test.ts
@@ -31,7 +31,7 @@ describe("AutoLog", () => {
   });
 
   test("calls the log function when accessing a property", async () => {
-    @AutoLog({ logger, level, enablePropertyLoging: true })
+    @AutoLog({ logger, level, enablePropertyLogging: true })
     class MyPropertyLoggingClass {
       public property = "aProperty";
 

--- a/test/vitest/property-decorators.test.ts
+++ b/test/vitest/property-decorators.test.ts
@@ -35,7 +35,7 @@ describe("Property Decorators", () => {
 
   describe("@AutoLogPropLevel", () => {
     test("changes the log level of a tagged property to a particular level when calling the logger function", async () => {
-      @AutoLog({ logger, level, enablePropertyLoging: true })
+      @AutoLog({ logger, level, enablePropertyLogging: true })
       class MyClass {
         @AutoLogPropLevel("info")
         public property = "aProperty";


### PR DESCRIPTION
Simple fix to rename a parameter.  This is technically a breaking change, but since we're in semver major version 0, this is fine IMO.